### PR TITLE
feat: add --output-file option to write report to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Finally, create the main function to run the load test:
 #[tokio::main]
 async fn main() -> Result<()> {
     let bs = HttpBench::parse();
-    rlt::cli::run(bs.bench_opts, bs).await
+    rlt::cli::run(bs.bench_opts.clone(), bs).await
 }
 ```
 

--- a/examples/http_reqwest.rs
+++ b/examples/http_reqwest.rs
@@ -39,5 +39,5 @@ impl BenchSuite for HttpBench {
 #[tokio::main]
 async fn main() -> Result<()> {
     let bs = HttpBench::parse();
-    rlt::cli::run(bs.bench_opts, bs).await
+    rlt::cli::run(bs.bench_opts.clone(), bs).await
 }

--- a/examples/postgres.rs
+++ b/examples/postgres.rs
@@ -97,5 +97,5 @@ impl BenchSuite for DBBench {
 #[tokio::main]
 async fn main() -> Result<()> {
     let bs: DBBench = DBBench::parse();
-    rlt::cli::run(bs.bench_opts, bs).await
+    rlt::cli::run(bs.bench_opts.clone(), bs).await
 }


### PR DESCRIPTION
When using shell redirection (e.g., `-o json > output.json`), the TUI is hidden because stdout is no longer a TTY. This new option allows saving the report to a file while keeping the TUI visible during the benchmark.

```bash
Usage:
 -o json -O result.json   # TUI shown + output saved to file
 --output-file result.txt # Long form
```

Note: BenchCli no longer implements Copy since PathBuf is not Copy.. Examples updated to use .clone() accordingly.