### PR TITLE
chore: upgrade Rust edition to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = [
     "command-line-utilities",
     "development-tools::profiling",
 ]
-edition = "2021"
+edition = "2024"
 keywords = ["performance", "load-testing", "benchmark", "cli"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/examples/http_hyper.rs
+++ b/examples/http_hyper.rs
@@ -6,10 +6,10 @@ use http_body_util::{BodyExt, Full};
 use hyper::Uri;
 use hyper_tls::HttpsConnector;
 use hyper_util::{
-    client::legacy::{connect::HttpConnector, Client},
+    client::legacy::{Client, connect::HttpConnector},
     rt::TokioExecutor,
 };
-use rlt::{bench_cli, BenchSuite, IterInfo, IterReport};
+use rlt::{BenchSuite, IterInfo, IterReport, bench_cli};
 use tokio::time::Instant;
 
 bench_cli!(Opts, {

--- a/examples/http_reqwest.rs
+++ b/examples/http_reqwest.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use clap::Parser;
 use reqwest::{Client, Url};
-use rlt::{bench_cli, bench_cli_run, BenchSuite, IterInfo, IterReport};
+use rlt::{BenchSuite, IterInfo, IterReport, bench_cli, bench_cli_run};
 use tokio::time::Instant;
 
 bench_cli!(HttpBench, {

--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use clap::Parser;
-use rlt::{cli::BenchCli, IterInfo, IterReport, StatelessBenchSuite, Status, StatusKind};
+use rlt::{IterInfo, IterReport, StatelessBenchSuite, Status, StatusKind, cli::BenchCli};
 use tokio::time::{Duration, Instant};
 
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[derive(Clone)]
 struct SimpleBench;

--- a/examples/postgres.rs
+++ b/examples/postgres.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use clap::Parser;
-use rlt::{bench_cli, bench_cli_run, BenchSuite, IterInfo, IterReport, Status};
+use rlt::{BenchSuite, IterInfo, IterReport, Status, bench_cli, bench_cli_run};
 use tokio::time::Instant;
 use tokio_postgres::{Client, NoTls};
 

--- a/examples/simple_stateless.rs
+++ b/examples/simple_stateless.rs
@@ -2,8 +2,9 @@ use anyhow::Result;
 use async_trait::async_trait;
 use clap::Parser;
 use rlt::{
+    IterReport, Status,
     cli::BenchCli,
-    IterReport, Status, {IterInfo, StatelessBenchSuite},
+    {IterInfo, StatelessBenchSuite},
 };
 use tokio::time::{Duration, Instant};
 

--- a/examples/warmup.rs
+++ b/examples/warmup.rs
@@ -1,14 +1,15 @@
 use std::sync::{
-    atomic::{AtomicU64, Ordering},
     Arc,
+    atomic::{AtomicU64, Ordering},
 };
 
 use anyhow::Result;
 use async_trait::async_trait;
 use clap::Parser;
 use rlt::{
+    IterReport, Status,
     cli::BenchCli,
-    IterReport, Status, {IterInfo, StatelessBenchSuite},
+    {IterInfo, StatelessBenchSuite},
 };
 use tokio::time::{Duration, Instant};
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,16 +97,16 @@
 use std::{
     fs::File,
     io::stdout,
-    num::{NonZeroU32, NonZeroU64, NonZeroU8},
+    num::{NonZeroU8, NonZeroU32, NonZeroU64},
     path::PathBuf,
 };
 
 use clap::{
-    builder::{
-        styling::{AnsiColor, Effects},
-        Styles,
-    },
     Parser, ValueEnum,
+    builder::{
+        Styles,
+        styling::{AnsiColor, Effects},
+    },
 };
 use crossterm::tty::IsTty;
 use tokio::sync::{mpsc, watch};

--- a/src/collector/tui.rs
+++ b/src/collector/tui.rs
@@ -1,19 +1,19 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use crossterm::{
-    cursor,
+    ExecutableCommand, cursor,
     event::{Event, KeyCode, KeyEvent, KeyModifiers},
-    terminal, ExecutableCommand,
+    terminal,
 };
 use itertools::Itertools;
 use nonzero_ext::nonzero;
 use ratatui::{
+    CompletedFrame, Frame,
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Color, Style, Stylize},
     text::Line,
-    widgets::{block::Title, BarChart, Block, Borders, Clear, Gauge, Padding, Paragraph},
-    CompletedFrame, Frame,
+    widgets::{BarChart, Block, Borders, Clear, Gauge, Padding, Paragraph, block::Title},
 };
 use std::{collections::HashMap, fmt, io, num::NonZeroU8, time::Duration};
 use tokio::{
@@ -431,7 +431,7 @@ fn render_process_gauge(
 fn render_status_dist(frame: &mut Frame, area: Rect, status_dist: &HashMap<Status, u64>) {
     let dist = status_dist
         .iter()
-        .sorted_by_key(|(_, &cnt)| std::cmp::Reverse(cnt))
+        .sorted_by_key(|&(_, cnt)| std::cmp::Reverse(cnt))
         .map(|(status, cnt)| {
             let s = format!("{} {} iters", status, cnt);
             let s = match status.kind() {
@@ -454,7 +454,7 @@ fn render_error_dist(frame: &mut Frame, area: Rect, error_dist: &HashMap<String,
 
     let dist = error_dist
         .iter()
-        .sorted_by_key(|(_, &cnt)| std::cmp::Reverse(cnt))
+        .sorted_by_key(|&(_, cnt)| std::cmp::Reverse(cnt))
         .map(|(err, cnt)| Line::from(format!("[{cnt}] {err}")))
         .collect_vec();
     let p = Paragraph::new(dist).block(Block::new().title("Error distribution").borders(Borders::ALL));

--- a/src/reporter/text.rs
+++ b/src/reporter/text.rs
@@ -1,12 +1,12 @@
 use crossterm::style::{StyledContent, Stylize};
 use itertools::Itertools;
 use std::{cmp::Reverse, collections::HashMap, io::Write};
-use tabled::settings::object::{Cell, Columns, FirstColumn, FirstRow, LastColumn, Object, Rows};
 use tabled::settings::Padding;
 use tabled::settings::PaddingColor;
+use tabled::settings::object::{Cell, Columns, FirstColumn, FirstRow, LastColumn, Object, Rows};
 use tabled::{
     builder::Builder,
-    settings::{themes::Colorization, Alignment, Color, Margin, Style},
+    settings::{Alignment, Color, Margin, Style, themes::Colorization},
 };
 
 use crate::duration::TimeUnit;
@@ -219,7 +219,7 @@ fn print_latency_percentiles(w: &mut dyn Write, hist: &LatencyHistogram, u: Time
 fn print_status(w: &mut dyn Write, status: &HashMap<Status, u64>) -> anyhow::Result<()> {
     let status_v = status
         .iter()
-        .sorted_unstable_by_key(|(_, &cnt)| Reverse(cnt))
+        .sorted_unstable_by_key(|&(_, cnt)| Reverse(cnt))
         .collect_vec();
     writeln!(w, "{}", "Status distribution".h1())?;
     if !status_v.is_empty() {
@@ -244,7 +244,7 @@ fn print_error(w: &mut dyn Write, report: &BenchReport) -> anyhow::Result<()> {
     let error_v = report
         .error_dist
         .iter()
-        .sorted_unstable_by_key(|(_, &cnt)| Reverse(cnt))
+        .sorted_unstable_by_key(|&(_, cnt)| Reverse(cnt))
         .collect_vec();
     let max = error_v.iter().map(|(_, iters)| iters).max().unwrap();
     let iters_width = max.to_string().len();

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -3,14 +3,14 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::{
     sync::{
-        atomic::{AtomicU64, Ordering},
         Arc,
+        atomic::{AtomicU64, Ordering},
     },
     time::Duration,
 };
 use tokio::{
     select,
-    sync::{mpsc, watch, Barrier},
+    sync::{Barrier, mpsc, watch},
     task::JoinSet,
 };
 use tokio_util::sync::CancellationToken;
@@ -236,10 +236,10 @@ where
                 // Run main benchmark iterations
                 loop {
                     info.runner_seq = b.seq.fetch_add(1, Ordering::Relaxed);
-                    if let Some(iterations) = iters {
-                        if info.runner_seq >= iterations {
-                            break;
-                        }
+                    if let Some(iterations) = iters
+                        && info.runner_seq >= iterations
+                    {
+                        break;
                     }
 
                     #[cfg(feature = "rate_limit")]


### PR DESCRIPTION
- Update edition from 2021 to 2024 in Cargo.toml
- Fix pattern matching for Rust 2024's stricter rules
- Use if-let chains syntax for collapsible if statements
- Reformat imports to comply with new edition's ordering rules