### PR TITLE
refactor: tighten public API surface

### DIFF
--- a/src/baseline/mod.rs
+++ b/src/baseline/mod.rs
@@ -64,11 +64,11 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Current schema version for baseline files.
-pub const SCHEMA_VERSION: u32 = 1;
+pub(crate) const SCHEMA_VERSION: u32 = 1;
 
 /// Benchmark configuration for comparability checks.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BenchConfig {
+pub(crate) struct BenchConfig {
     /// Number of concurrent workers.
     pub concurrency: u32,
     /// Duration in seconds (if set).
@@ -88,7 +88,7 @@ pub struct BenchConfig {
 
 /// Baseline metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BaselineMetadata {
+pub(crate) struct BaselineMetadata {
     /// Name of the baseline.
     pub name: String,
     /// When the baseline was created.
@@ -101,7 +101,7 @@ pub struct BaselineMetadata {
 
 /// Summary statistics for serialization.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Summary {
+pub(crate) struct Summary {
     /// Success ratio (0.0 to 1.0).
     pub success_ratio: f64,
     /// Total elapsed time in seconds.
@@ -118,7 +118,7 @@ pub struct Summary {
 
 /// Rate-based summary (total and rate per second).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RateSummary {
+pub(crate) struct RateSummary {
     /// Total count.
     pub total: u64,
     /// Rate per second.
@@ -127,7 +127,7 @@ pub struct RateSummary {
 
 /// Latency statistics.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LatencyStats {
+pub(crate) struct LatencyStats {
     /// Minimum latency in seconds.
     pub min: f64,
     /// Maximum latency in seconds.
@@ -142,7 +142,7 @@ pub struct LatencyStats {
 
 /// Latency data including stats, percentiles, and histogram.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Latency {
+pub(crate) struct Latency {
     /// Basic statistics.
     pub stats: LatencyStats,
     /// Percentile values (e.g., "p90" -> 0.003123).
@@ -153,7 +153,7 @@ pub struct Latency {
 
 /// Serializable form of BenchReport for JSON storage.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SerializableReport {
+pub(crate) struct SerializableReport {
     /// Summary statistics.
     pub summary: Summary,
     /// Latency data (if available).
@@ -169,12 +169,12 @@ pub struct SerializableReport {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Baseline {
     /// Schema version for forward compatibility.
-    pub schema_version: u32,
+    pub(crate) schema_version: u32,
     /// Baseline metadata.
-    pub metadata: BaselineMetadata,
+    pub(crate) metadata: BaselineMetadata,
     /// Report data (flattened into the baseline).
     #[serde(flatten)]
-    pub report: SerializableReport,
+    pub(crate) report: SerializableReport,
 }
 
 impl Baseline {

--- a/src/collector/silent.rs
+++ b/src/collector/silent.rs
@@ -21,7 +21,7 @@ pub struct SilentCollector {
 
 impl SilentCollector {
     /// Create a new silent report collector.
-    pub fn new(
+    pub(crate) fn new(
         bench_opts: BenchOpts,
         res_rx: UnboundedReceiver<Result<IterReport>>,
         cancel: CancellationToken,

--- a/src/collector/tui.rs
+++ b/src/collector/tui.rs
@@ -38,17 +38,17 @@ const SECOND: Duration = Duration::from_secs(1);
 /// A report collector with real-time TUI support.
 pub struct TuiCollector {
     /// The benchmark options.
-    pub bench_opts: BenchOpts,
+    pub(crate) bench_opts: BenchOpts,
     /// Refresh rate for the tui collector, in frames per second (fps)
-    pub fps: NonZeroU8,
+    pub(crate) fps: NonZeroU8,
     /// The receiver for iteration reports.
-    pub res_rx: mpsc::UnboundedReceiver<Result<IterReport>>,
+    pub(crate) res_rx: mpsc::UnboundedReceiver<Result<IterReport>>,
     /// The sender for pausing the benchmark runner.
-    pub pause: watch::Sender<bool>,
+    pub(crate) pause: watch::Sender<bool>,
     /// The cancellation token for the benchmark runner.
-    pub cancel: CancellationToken,
+    pub(crate) cancel: CancellationToken,
     /// Whether to quit the benchmark automatically when finished.
-    pub auto_quit: bool,
+    pub(crate) auto_quit: bool,
 
     /// The internal state of the TUI collector.
     state: TuiCollectorState,
@@ -63,7 +63,7 @@ struct TuiCollectorState {
 
 impl TuiCollector {
     /// Create a new TUI report collector.
-    pub fn new(
+    pub(crate) fn new(
         bench_opts: BenchOpts,
         fps: NonZeroU8,
         res_rx: mpsc::UnboundedReceiver<Result<IterReport>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,10 @@ mod duration;
 mod histogram;
 mod report;
 mod runner;
-mod stats;
 mod status;
 mod util;
+
+pub(crate) mod stats;
 
 pub mod baseline;
 pub mod cli;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -31,7 +31,7 @@ use crate::{
 
 /// Core options for the benchmark runner.
 #[derive(Clone, Debug)]
-pub struct BenchOpts {
+pub(crate) struct BenchOpts {
     /// Start time of the benchmark.
     pub clock: Clock,
 
@@ -102,7 +102,7 @@ where
 
 /// A Benchmark runner with a given benchmark suite and control options.
 #[derive(Clone)]
-pub struct Runner<BS>
+pub(crate) struct Runner<BS>
 where
     BS: BenchSuite,
 {


### PR DESCRIPTION
Reduce the public API by making internal implementation details crate-private:

- stats module: entirely pub(crate)
- runner: BenchOpts, Runner
- baseline: internal serialization types (BenchConfig, BaselineMetadata, Summary, RateSummary, LatencyStats, Latency, SerializableReport, SCHEMA_VERSION) and Baseline struct fields
- collector: TuiCollector/SilentCollector constructors and fields

This makes the API more maintainable while preserving extensibility for custom ReportCollector and BenchReporter implementations.