### PR TITLE
chore: align rustfmt edition with crate edition (2024)

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2021"
+edition = "2024"
 max_width = 120
 reorder_imports = true
 struct_lit_width = 60


### PR DESCRIPTION
## Description

Update `rustfmt.toml` edition from `2021` to `2024` to match the crate's edition in `Cargo.toml`.

## Related Issue

Fixes #78

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if needed