### PR TITLE
fix: correct CI MSRV configuration for edition 2024

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -99,7 +99,7 @@ jobs:
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: ["1.56.1"] # 2021 edition requires 1.56
+        msrv: ["1.85"] # 2024 edition requires 1.85
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ categories = [
     "development-tools::profiling",
 ]
 edition = "2024"
+rust-version = "1.85"
 keywords = ["performance", "load-testing", "benchmark", "cli"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/stats/window.rs
+++ b/src/stats/window.rs
@@ -136,13 +136,13 @@ impl RotateWindowGroup {
     pub fn rotate(&mut self) {
         self.counter += 1;
         self.stats_by_sec.rotate(IterStats::new());
-        if self.counter.is_multiple_of(10) {
+        if self.counter % 10 == 0 {
             self.stats_by_10sec.rotate(IterStats::new());
         }
-        if self.counter.is_multiple_of(60) {
+        if self.counter % 60 == 0 {
             self.stats_by_min.rotate(IterStats::new());
         }
-        if self.counter.is_multiple_of(600) {
+        if self.counter % 600 == 0 {
             self.stats_by_10min.rotate(IterStats::new());
         }
     }


### PR DESCRIPTION
## Description

This PR fixes the CI MSRV configuration to align with the crate's `edition = "2024"` requirement.

**Changes:**
- Add `rust-version = "1.85"` to `Cargo.toml` as the single source of truth for MSRV
- Update CI workflow MSRV matrix from `1.56.1` to `1.85` (required for edition 2024)
- Replace `is_multiple_of()` calls with `% n == 0` for Rust 1.85 compatibility (the former is stable since 1.87)

## Related Issue

Fixes #79

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if needed