### PR TITLE
fix: print baseline save message to stderr only in text mode

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -344,12 +344,15 @@ where
     // Save baseline if requested (after comparison, so we can compare-then-save)
     if let Some(ref name) = cli.save_baseline {
         baseline::save(&baseline_dir, name, &report, &cli)?;
-        println!();
-        println!(
-            "Baseline '{}' saved to {}",
-            name,
-            baseline_dir.join(format!("{}.json", name)).display()
-        );
+        // Only print save message in Text mode to keep JSON output clean
+        if matches!(cli.output, ReportFormat::Text) {
+            eprintln!();
+            eprintln!(
+                "Baseline '{}' saved to {}",
+                name,
+                baseline_dir.join(format!("{}.json", name)).display()
+            );
+        }
     }
 
     // Handle regression for CI


### PR DESCRIPTION
## Summary

- Only print baseline save message in Text output mode to keep JSON output clean
- Use stderr instead of stdout for informational messages

## Test plan

- [x] Verified `--output json --save-baseline ...` produces valid JSON on stdout
- [x] Verified baseline save message appears on stderr in Text mode

Closes #66