### PR TITLE
fix: make TUI terminal cleanup resilient to avoid panics in Drop

### DIFF
--- a/src/collector/tui.rs
+++ b/src/collector/tui.rs
@@ -146,9 +146,9 @@ impl Terminal {
 
 impl Drop for Terminal {
     fn drop(&mut self) {
-        std::io::stdout().execute(terminal::LeaveAlternateScreen).unwrap();
-        std::io::stdout().execute(cursor::Show).unwrap();
-        crossterm::terminal::disable_raw_mode().unwrap();
+        let _ = std::io::stdout().execute(terminal::LeaveAlternateScreen);
+        let _ = std::io::stdout().execute(cursor::Show);
+        let _ = crossterm::terminal::disable_raw_mode();
     }
 }
 


### PR DESCRIPTION
## Description

Use best-effort cleanup with error suppression in `Terminal::drop()` instead of `unwrap()` to prevent double panics when cleanup fails while another panic is in flight.

**Before:**
```rust
impl Drop for Terminal {
    fn drop(&mut self) {
        std::io::stdout().execute(terminal::LeaveAlternateScreen).unwrap();
        std::io::stdout().execute(cursor::Show).unwrap();
        crossterm::terminal::disable_raw_mode().unwrap();
    }
}
```

**After:**
```rust
impl Drop for Terminal {
    fn drop(&mut self) {
        let _ = std::io::stdout().execute(terminal::LeaveAlternateScreen);
        let _ = std::io::stdout().execute(cursor::Show);
        let _ = crossterm::terminal::disable_raw_mode();
    }
}
```

## Related Issue

Fixes #69

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if needed