### PR TITLE
fix: use Fill constraints for TUI three-column layout

### DIFF
--- a/src/collector/tui.rs
+++ b/src/collector/tui.rs
@@ -253,11 +253,7 @@ impl TuiCollector {
 
                 let mid = Layout::default()
                     .direction(Direction::Horizontal)
-                    .constraints([
-                        Constraint::Percentage(50),
-                        Constraint::Percentage(50),
-                        Constraint::Percentage(50),
-                    ])
+                    .constraints([Constraint::Fill(1), Constraint::Fill(1), Constraint::Fill(1)])
                     .split(rows[0]);
 
                 let bot = Layout::default()


### PR DESCRIPTION
## Description

Replace `Constraint::Percentage(50)` × 3 (totaling 150%) with `Constraint::Fill(1)` × 3 for the top row layout. This ensures all three panels (stats for last N, stats overall, status distribution) receive equal space and remain visible on any terminal width.

## Related Issue

Fixes #68

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if needed