### PR TITLE
feat(tui): default to auto time window

### DIFF
--- a/src/collector/tui/mod.rs
+++ b/src/collector/tui/mod.rs
@@ -16,8 +16,8 @@
 //!
 //! # Keyboard Controls
 //!
-//! - `+`/`-`: Zoom time window in/out
-//! - `a`: Auto-select time window based on elapsed time
+//! - `+`/`-`: Zoom time window in/out (switch to manual mode)
+//! - `a`: Auto time window (default)
 //! - `p`: Pause/resume the benchmark
 //! - `l`: Toggle log viewer (requires `tracing` feature)
 //! - `q` or `Ctrl+C`: Quit the benchmark
@@ -39,7 +39,7 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 
-use state::{TimeWindow, TuiCollectorState};
+use state::{TimeWindowMode, TuiCollectorState};
 use terminal::Terminal;
 
 use crate::{
@@ -99,7 +99,7 @@ impl TuiCollector {
         auto_quit: bool,
     ) -> Result<Self> {
         let state = TuiCollectorState {
-            tm_win: TimeWindow::Second,
+            tm_win: TimeWindowMode::Auto,
             finished: false,
             #[cfg(feature = "tracing")]
             log: tui_log::LogState::from_env()?,
@@ -189,6 +189,7 @@ impl TuiCollector {
 
             terminal.draw(|f| {
                 let paused = *self.pause.borrow();
+                let tw = self.state.tm_win.effective(elapsed);
                 render::render_dashboard(
                     f,
                     &stats.counter,
@@ -197,7 +198,7 @@ impl TuiCollector {
                     paused,
                     self.state.finished,
                     &latest_stats,
-                    self.state.tm_win,
+                    tw,
                     status_dist,
                     error_dist,
                     &latest_iters,

--- a/src/collector/tui/state.rs
+++ b/src/collector/tui/state.rs
@@ -1,7 +1,7 @@
 use std::{fmt, time::Duration};
 
 pub(super) struct TuiCollectorState {
-    pub(super) tm_win: TimeWindow,
+    pub(super) tm_win: TimeWindowMode,
     pub(super) finished: bool,
     #[cfg(feature = "tracing")]
     pub(super) log: super::tui_log::LogState,
@@ -22,6 +22,23 @@ impl TimeWindow {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum TimeWindowMode {
+    /// Automatically select the best time window based on elapsed time.
+    Auto,
+    /// Use a fixed, user-selected time window.
+    Manual(TimeWindow),
+}
+
+impl TimeWindowMode {
+    pub(super) fn effective(&self, elapsed: Duration) -> TimeWindow {
+        match *self {
+            TimeWindowMode::Auto => TimeWindow::auto_select(elapsed),
+            TimeWindowMode::Manual(tw) => tw,
+        }
+    }
+}
+
 impl fmt::Display for TimeWindow {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", humantime::format_duration(Duration::from(*self)))
@@ -35,6 +52,13 @@ impl From<TimeWindow> for Duration {
 }
 
 impl TimeWindow {
+    fn auto_select(elapsed: Duration) -> Self {
+        *Self::variants()
+            .iter()
+            .rfind(|&&ts| elapsed > Duration::from(ts))
+            .unwrap_or(&TimeWindow::Second)
+    }
+
     pub fn format(&self, n: usize) -> String {
         match self {
             TimeWindow::Second => format!("{}s", n),
@@ -88,5 +112,28 @@ mod tests {
         assert_eq!(TimeWindow::TenSec.format(3), "30s");
         assert_eq!(TimeWindow::Minute.format(3), "3m");
         assert_eq!(TimeWindow::TenMin.format(3), "30m");
+    }
+
+    #[test]
+    fn time_window_mode_effective_manual() {
+        let mode = TimeWindowMode::Manual(TimeWindow::Minute);
+        assert_eq!(mode.effective(Duration::from_secs(0)), TimeWindow::Minute);
+        assert_eq!(mode.effective(Duration::from_secs(999)), TimeWindow::Minute);
+    }
+
+    #[test]
+    fn time_window_mode_effective_auto_selects_by_elapsed() {
+        use TimeWindow::*;
+
+        let mode = TimeWindowMode::Auto;
+
+        // NOTE: Mirrors the existing `a` key behavior: boundaries are strict `>` comparisons.
+        assert_eq!(mode.effective(Duration::from_secs(0)), Second);
+        assert_eq!(mode.effective(Duration::from_secs(1)), Second);
+        assert_eq!(mode.effective(Duration::from_secs(2)), Second);
+
+        assert_eq!(mode.effective(Duration::from_secs(11)), TenSec);
+        assert_eq!(mode.effective(Duration::from_secs(61)), Minute);
+        assert_eq!(mode.effective(Duration::from_secs(601)), TenMin);
     }
 }


### PR DESCRIPTION
## Description

Default the TUI time window to Auto mode and keep it in sync with elapsed time.

- `+`/`-`: switch to manual mode (zoom)
- `a`: return to auto mode

## Related Issue

N/A

## Checklist

- [x] I have tested my changes locally (`cargo fmt --check`, `cargo clippy --locked --all-features --all-targets -- -D warnings`, `cargo test --locked --all-features --all-targets`, `cargo test --locked --all-features --doc`)
- [x] I have updated documentation if needed (not needed for this change)
