### PR TITLE
perf(stats): avoid per-frame HashMap cloning in windows

### DIFF
--- a/src/collector/silent.rs
+++ b/src/collector/silent.rs
@@ -64,7 +64,7 @@ impl super::ReportCollector for SilentCollector {
                     Some(Ok(report)) => {
                         *status_dist.entry(report.status).or_default() += 1;
                         hist.record(report.duration)?;
-                        stats += &report;
+                        stats.append(&report);
                     }
                     Some(Err(e)) => *error_dist.entry(e.to_string()).or_default() += 1,
                     None => break,

--- a/src/collector/tui/mod.rs
+++ b/src/collector/tui/mod.rs
@@ -157,7 +157,7 @@ impl TuiCollector {
                         biased;
                         _ = ui_ticker.tick() => break,
                         _ = latest_stats_ticker.tick() => {
-                            latest_stats.rotate(stats);
+                            latest_stats.rotate(stats.counter);
                             continue;
                         }
                         _ = latest_iters_ticker.tick() => {
@@ -169,7 +169,7 @@ impl TuiCollector {
                                 *status_dist.entry(report.status).or_default() += 1;
                                 hist.record(report.duration)?;
                                 latest_iters.push(&report);
-                                *stats += &report;
+                                stats.append(&report);
                             }
                             Some(Err(e)) => *error_dist.entry(e.to_string()).or_default() += 1,
                             None => {

--- a/src/collector/tui/render.rs
+++ b/src/collector/tui/render.rs
@@ -74,18 +74,18 @@ pub(super) fn render_dashboard(
 }
 
 fn render_stats_timewin(frame: &mut Frame, area: Rect, stats: &RotateDiffWindowGroup, tw: TimeWindow) {
-    let (stats, duration) = match tw {
-        TimeWindow::Second => stats.stats_last_sec(),
-        TimeWindow::TenSec => stats.stats_last_10sec(),
-        TimeWindow::Minute => stats.stats_last_min(),
-        TimeWindow::TenMin => stats.stats_last_10min(),
+    let (counter, duration) = match tw {
+        TimeWindow::Second => stats.counter_last_sec(),
+        TimeWindow::TenSec => stats.counter_last_10sec(),
+        TimeWindow::Minute => stats.counter_last_min(),
+        TimeWindow::TenMin => stats.counter_last_10min(),
     };
 
     render_stats(
         frame,
         area,
         Line::from(vec!["Stats for ".into(), format!("last {}", tw).yellow().bold()]),
-        &stats.counter,
+        &counter,
         duration,
     );
 }
@@ -232,12 +232,12 @@ fn render_error_dist(frame: &mut Frame, area: Rect, error_dist: &HashMap<String,
 
 fn render_iter_hist(frame: &mut Frame, area: Rect, rwg: &RotateWindowGroup, tw: TimeWindow) {
     let win = match tw {
-        TimeWindow::Second => &rwg.stats_by_sec,
-        TimeWindow::TenSec => &rwg.stats_by_10sec,
-        TimeWindow::Minute => &rwg.stats_by_min,
-        TimeWindow::TenMin => &rwg.stats_by_10min,
+        TimeWindow::Second => &rwg.counters_by_sec,
+        TimeWindow::TenSec => &rwg.counters_by_10sec,
+        TimeWindow::Minute => &rwg.counters_by_min,
+        TimeWindow::TenMin => &rwg.counters_by_10min,
     };
-    let cols = win.iter().map(|w| w.counter.iters.to_string().len()).max().unwrap_or(0);
+    let cols = win.iter().map(|w| w.iters.to_string().len()).max().unwrap_or(0);
     let data = win
         .iter()
         .enumerate()
@@ -248,7 +248,7 @@ fn render_iter_hist(frame: &mut Frame, area: Rect, rwg: &RotateWindowGroup, tw: 
                     s.push(' ');
                 }
             }
-            (s, n.counter.iters)
+            (s, n.iters)
         })
         .collect_vec();
 

--- a/src/stats/counter.rs
+++ b/src/stats/counter.rs
@@ -17,14 +17,14 @@ use crate::report::IterReport;
 ///
 /// # Operations
 ///
-/// - Can be accumulated from [`IterReport`] using `+=` operator.
+/// - Can be accumulated from [`IterReport`] using [`append`](Self::append).
 /// - Supports subtraction via `-=` for calculating deltas.
 ///
 /// # Example
 ///
 /// ```ignore
 /// let mut counter = Counter::default();
-/// counter += &iter_report;  // Accumulate from an iteration report
+/// counter.append(&iter_report);  // Accumulate from an iteration report
 /// println!("Total iterations: {}", counter.iters);
 /// ```
 #[derive(Default, Clone, Copy, Debug)]
@@ -39,8 +39,9 @@ pub struct Counter {
     pub duration: Duration,
 }
 
-impl std::ops::AddAssign<&IterReport> for Counter {
-    fn add_assign(&mut self, stats: &IterReport) {
+impl Counter {
+    /// Accumulate metrics from a single iteration report.
+    pub fn append(&mut self, stats: &IterReport) {
         self.iters += 1;
         self.items += stats.items;
         self.bytes += stats.bytes;
@@ -54,5 +55,15 @@ impl std::ops::SubAssign<&Counter> for Counter {
         self.items -= rhs.items;
         self.bytes -= rhs.bytes;
         self.duration -= rhs.duration;
+    }
+}
+
+impl std::ops::Sub<&Counter> for &Counter {
+    type Output = Counter;
+
+    fn sub(self, rhs: &Counter) -> Counter {
+        let mut out = *self;
+        out -= rhs;
+        out
     }
 }

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -44,33 +44,16 @@ impl IterStats {
     pub fn new() -> Self {
         Self { counter: Counter::default(), details: HashMap::new() }
     }
+
+    pub fn append(&mut self, stats: &IterReport) {
+        self.counter.append(stats);
+        let counter = self.details.entry(stats.status).or_default();
+        counter.append(stats);
+    }
 }
 
 impl Default for IterStats {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl std::ops::AddAssign<&IterReport> for IterStats {
-    fn add_assign(&mut self, stats: &IterReport) {
-        self.counter += stats;
-        let counter = self.details.entry(stats.status).or_default();
-        *counter += stats;
-    }
-}
-
-impl std::ops::Sub<&IterStats> for &IterStats {
-    type Output = IterStats;
-
-    fn sub(self, rhs: &IterStats) -> IterStats {
-        let mut aggregate = self.counter;
-        let mut details = self.details.clone();
-        for (k, v) in &rhs.details {
-            let counter = details.entry(*k).or_default();
-            *counter -= v;
-        }
-        aggregate -= &rhs.counter;
-        IterStats { counter: aggregate, details }
     }
 }


### PR DESCRIPTION
## Description

Optimize TUI window stats hot path by storing only `Counter` snapshots in rolling
windows. This avoids per-frame cloning of `IterStats` (and its `HashMap` details)
while keeping the same visible TUI behavior.

Key changes:
- Window buckets now store `Counter`
- Window field/method names updated to reflect counters
- TUI updated to consume counter deltas
- Counter/IterStats aggregation uses explicit `append()`

## Related Issue

Fixes #47

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if needed
