### PR TITLE
refactor(api): relax Sync bounds on BenchSuite and WorkerState

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -285,8 +285,8 @@ pub enum ReportFormat {
 /// Run the benchmark with the given CLI options and benchmark suite.
 pub async fn run<BS>(cli: BenchCli, bench_suite: BS) -> anyhow::Result<()>
 where
-    BS: BenchSuite + Send + Sync + 'static,
-    BS::WorkerState: Send + Sync + 'static,
+    BS: BenchSuite + Send + 'static,
+    BS::WorkerState: Send + 'static,
 {
     // Resolve baseline directory
     let baseline_dir = baseline::resolve_baseline_dir(cli.baseline_dir.as_deref());

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -136,8 +136,8 @@ impl IterInfo {
 
 impl<BS> Runner<BS>
 where
-    BS: BenchSuite + Send + Sync + 'static,
-    BS::WorkerState: Send + Sync + 'static,
+    BS: BenchSuite + Send + 'static,
+    BS::WorkerState: Send + 'static,
 {
     /// Create a new benchmark runner with the given benchmark suite and options.
     pub fn new(


### PR DESCRIPTION
## Description

Runner clones the benchmark suite per worker, and each worker owns its WorkerState. Both are only moved into a single Tokio task and never shared by reference across tasks, so requiring Sync is unnecessary and blocks Send-only state types.

We keep Send + 'static because worker futures are spawned onto the runtime.

## Related Issue

Closes #76

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if needed
