### PR TITLE
refactor(stats): configurable RotateWindowGroup periods

### DIFF
--- a/src/collector/tui/mod.rs
+++ b/src/collector/tui/mod.rs
@@ -39,7 +39,7 @@ use tokio::{
 };
 use tokio_util::sync::CancellationToken;
 
-use state::{TimeWindowMode, TuiCollectorState};
+use state::{TimeWindow, TimeWindowMode, TuiCollectorState};
 use terminal::Terminal;
 
 use crate::{
@@ -136,7 +136,7 @@ impl TuiCollector {
         let clock = self.bench_opts.clock.clone();
         let mut terminal = Terminal::new()?;
 
-        let mut latest_iters = RotateWindowGroup::new(nonzero!(60usize));
+        let mut latest_iters = RotateWindowGroup::new(nonzero!(60usize), TimeWindow::variants().iter().copied())?;
         let mut latest_iters_ticker = clock.ticker(SECOND);
 
         let mut latest_stats = RotateDiffWindow::new(self.fps.into());

--- a/src/collector/tui/render.rs
+++ b/src/collector/tui/render.rs
@@ -226,12 +226,9 @@ fn render_error_dist(frame: &mut Frame, area: Rect, error_dist: &HashMap<String,
 }
 
 fn render_iter_hist(frame: &mut Frame, area: Rect, rwg: &RotateWindowGroup, tw: TimeWindow) {
-    let win = match tw {
-        TimeWindow::Second => &rwg.counters_by_sec,
-        TimeWindow::TenSec => &rwg.counters_by_10sec,
-        TimeWindow::Minute => &rwg.counters_by_min,
-        TimeWindow::TenMin => &rwg.counters_by_10min,
-    };
+    let win = rwg
+        .window_for_secs(tw as usize)
+        .expect("RotateWindowGroup missing TimeWindow period");
     let cols = win.iter().map(|w| w.iters.to_string().len()).max().unwrap_or(0);
     let data = win
         .iter()

--- a/src/collector/tui/state.rs
+++ b/src/collector/tui/state.rs
@@ -51,6 +51,12 @@ impl From<TimeWindow> for Duration {
     }
 }
 
+impl From<TimeWindow> for usize {
+    fn from(tw: TimeWindow) -> Self {
+        tw as usize
+    }
+}
+
 impl TimeWindow {
     fn auto_select(elapsed: Duration) -> Self {
         *Self::variants()

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! - [`Counter`] - Tracks basic metrics: iterations, items, bytes, and duration.
 //! - [`IterStats`] - Aggregates iteration statistics with per-status breakdowns.
-//! - [`RotateWindowGroup`] - Manages multiple rolling windows at different time scales.
+//! - [`RotateWindowGroup`] - Manages multiple rolling windows at configurable time scales.
 //! - [`RotateDiffWindow`] - Provides rate calculations over sliding windows.
 
 mod counter;


### PR DESCRIPTION
## Summary
- make RotateWindowGroup accept an iterator of periods and return anyhow::Result on validation
- store windows in a vector and rotate by configured periods
- update TUI to use TimeWindow::variants and window_for_secs
- add tests for period rotation and invalid periods

## Test Plan
- [x] cargo test -q
- [x] cargo clippy
