### PR TITLE
refactor(stats): clarify naming for counters and stats windows

### DIFF
--- a/src/baseline/compare.rs
+++ b/src/baseline/compare.rs
@@ -160,28 +160,28 @@ pub fn compare(
     regression_metrics: &[RegressionMetric],
 ) -> Comparison {
     let elapsed = report.elapsed.as_secs_f64();
-    let counter = &report.stats.counter;
+    let overall = &report.stats.overall;
     let baseline_summary = &baseline.report.summary;
 
     // Calculate throughput deltas
     let throughput = ThroughputDeltas {
         iters_rate: calculate_throughput_delta(
-            rate(counter.iters, elapsed),
+            rate(overall.iters, elapsed),
             baseline_summary.iters.rate,
             noise_threshold,
         ),
-        items_rate: if counter.items > 0 || baseline_summary.items.total > 0 {
+        items_rate: if overall.items > 0 || baseline_summary.items.total > 0 {
             Some(calculate_throughput_delta(
-                rate(counter.items, elapsed),
+                rate(overall.items, elapsed),
                 baseline_summary.items.rate,
                 noise_threshold,
             ))
         } else {
             None
         },
-        bytes_rate: if counter.bytes > 0 || baseline_summary.bytes.total > 0 {
+        bytes_rate: if overall.bytes > 0 || baseline_summary.bytes.total > 0 {
             Some(calculate_throughput_delta(
-                rate(counter.bytes, elapsed),
+                rate(overall.bytes, elapsed),
                 baseline_summary.bytes.rate,
                 noise_threshold,
             ))

--- a/src/baseline/storage.rs
+++ b/src/baseline/storage.rs
@@ -96,16 +96,16 @@ pub fn save(baseline_dir: &Path, name: &BaselineName, report: &BenchReport, cli:
 /// Create a Baseline from a BenchReport and CLI options.
 fn create_baseline(name: &str, report: &BenchReport, cli: &BenchCli) -> Baseline {
     let elapsed = report.elapsed.as_secs_f64();
-    let counter = &report.stats.counter;
+    let overall = &report.stats.overall;
 
     // Build summary
     let summary = Summary {
         success_ratio: report.success_ratio(),
         total_time: elapsed,
         concurrency: report.concurrency,
-        iters: RateSummary { total: counter.iters, rate: rate(counter.iters, elapsed) },
-        items: RateSummary { total: counter.items, rate: rate(counter.items, elapsed) },
-        bytes: RateSummary { total: counter.bytes, rate: rate(counter.bytes, elapsed) },
+        iters: RateSummary { total: overall.iters, rate: rate(overall.iters, elapsed) },
+        items: RateSummary { total: overall.items, rate: rate(overall.items, elapsed) },
+        bytes: RateSummary { total: overall.bytes, rate: rate(overall.bytes, elapsed) },
     };
 
     // Build latency (if available)

--- a/src/collector/silent.rs
+++ b/src/collector/silent.rs
@@ -64,7 +64,7 @@ impl super::ReportCollector for SilentCollector {
                     Some(Ok(report)) => {
                         *status_dist.entry(report.status).or_default() += 1;
                         hist.record(report.duration)?;
-                        stats.append(&report);
+                        stats.record(&report);
                     }
                     Some(Err(e)) => *error_dist.entry(e.to_string()).or_default() += 1,
                     None => break,

--- a/src/report.rs
+++ b/src/report.rs
@@ -41,15 +41,15 @@ pub struct BenchReport {
 impl BenchReport {
     /// Returns the success ratio of the benchmark.
     pub fn success_ratio(&self) -> f64 {
-        if self.stats.counter.iters == 0 {
+        if self.stats.overall.iters == 0 {
             return 0.0;
         }
         self.stats
-            .details
+            .by_status
             .iter()
             .filter(|(k, _)| k.kind() == StatusKind::Success)
             .map(|(_, v)| v.iters as f64)
             .sum::<f64>()
-            / self.stats.counter.iters as f64
+            / self.stats.overall.iters as f64
     }
 }

--- a/src/reporter/json.rs
+++ b/src/reporter/json.rs
@@ -46,30 +46,30 @@ pub struct JsonReporter;
 impl BenchReporter for JsonReporter {
     fn print(&self, w: &mut dyn Write, report: &BenchReport, comparison: Option<&Comparison>) -> anyhow::Result<()> {
         let elapsed = report.elapsed.as_secs_f64();
-        let counter = &report.stats.counter;
+        let overall = &report.stats.overall;
         let summary = Summary {
             success_ratio: report.success_ratio(),
             total_time: elapsed,
             concurrency: report.concurrency,
 
             iters: ItersSummary {
-                total: counter.iters,
-                rate: rate(counter.iters, elapsed),
-                bytes_per_iter: counter.bytes.checked_div(counter.iters),
+                total: overall.iters,
+                rate: rate(overall.iters, elapsed),
+                bytes_per_iter: overall.bytes.checked_div(overall.iters),
             },
 
             items: ItemsSummary {
-                total: counter.items,
-                rate: rate(counter.items, elapsed),
-                items_per_iter: if counter.iters > 0 {
-                    counter.items as f64 / counter.iters as f64
+                total: overall.items,
+                rate: rate(overall.items, elapsed),
+                items_per_iter: if overall.iters > 0 {
+                    overall.items as f64 / overall.iters as f64
                 } else {
                     0.0
                 },
-                bytes_per_item: counter.bytes.checked_div(counter.items),
+                bytes_per_item: overall.bytes.checked_div(overall.items),
             },
 
-            bytes: BytesSummary { total: counter.bytes, rate: rate(counter.bytes, elapsed) },
+            bytes: BytesSummary { total: overall.bytes, rate: rate(overall.bytes, elapsed) },
         };
 
         let latency = if report.hist.is_empty() {

--- a/src/reporter/text.rs
+++ b/src/reporter/text.rs
@@ -60,7 +60,7 @@ impl super::BenchReporter for TextReporter {
     fn print(&self, w: &mut dyn Write, report: &BenchReport, comparison: Option<&Comparison>) -> anyhow::Result<()> {
         print_summary(w, report)?;
 
-        if report.stats.counter.iters > 0 {
+        if report.stats.overall.iters > 0 {
             writeln!(w)?;
             print_latency(w, &report.hist)?;
 
@@ -146,7 +146,7 @@ fn render_bar(count: u64, max_count: u64) -> String {
 #[rustfmt::skip]
 fn print_summary(w: &mut dyn Write, report: &BenchReport) -> anyhow::Result<()> {
     let elapsed = report.elapsed.as_secs_f64();
-    let counter = &report.stats.counter;
+    let overall = &report.stats.overall;
 
     writeln!(w, "{}", "Summary".h1())?;
     writeln!(w, "  Benchmark took {} with concurrency {} ({} success)",
@@ -159,18 +159,18 @@ fn print_summary(w: &mut dyn Write, report: &BenchReport) -> anyhow::Result<()> 
         vec!["".into(), "Total".into(), "Rate".into()],
         vec![
             "Iters".into(),
-            format!("{}", counter.iters),
-            format!("{:.2}/s", rate(counter.iters, elapsed)),
+            format!("{}", overall.iters),
+            format!("{:.2}/s", rate(overall.iters, elapsed)),
         ],
         vec![
             "Items".into(),
-            format!("{}", counter.items),
-            format!("{:.2}/s", rate(counter.items, elapsed)),
+            format!("{}", overall.items),
+            format!("{:.2}/s", rate(overall.items, elapsed)),
         ],
         vec![
             "Bytes".into(),
-            format!("{:.2}", counter.bytes.adjusted()),
-            format!("{:.2}/s", rate(counter.bytes, elapsed).adjusted()?),
+            format!("{:.2}", overall.bytes.adjusted()),
+            format!("{:.2}/s", rate(overall.bytes, elapsed).adjusted()?),
         ],
     ];
     let mut stats = Builder::from(stats).build();

--- a/src/stats/counter.rs
+++ b/src/stats/counter.rs
@@ -1,7 +1,7 @@
 //! Basic counter for tracking benchmark metrics.
 //!
 //! This module provides [`Counter`], a simple structure for accumulating
-//! iteration counts, item counts, byte counts, and total duration.
+//! iteration counts, item counts, byte counts, and total latency.
 
 use std::time::Duration;
 
@@ -13,18 +13,18 @@ use crate::report::IterReport;
 /// - Number of iterations completed
 /// - Number of items processed (e.g., requests, records)
 /// - Number of bytes transferred
-/// - Total duration of all iterations
+/// - Total latency of all iterations
 ///
 /// # Operations
 ///
-/// - Can be accumulated from [`IterReport`] using [`append`](Self::append).
+/// - Can be accumulated from [`IterReport`] using [`record`](Self::record).
 /// - Supports subtraction via `-=` for calculating deltas.
 ///
 /// # Example
 ///
 /// ```ignore
 /// let mut counter = Counter::default();
-/// counter.append(&iter_report);  // Accumulate from an iteration report
+/// counter.record(&iter_report);  // Accumulate from an iteration report
 /// println!("Total iterations: {}", counter.iters);
 /// ```
 #[derive(Default, Clone, Copy, Debug)]
@@ -35,17 +35,17 @@ pub struct Counter {
     pub items: u64,
     /// Number of bytes transferred or processed.
     pub bytes: u64,
-    /// Total duration of all iterations combined.
-    pub duration: Duration,
+    /// Sum of iteration latencies.
+    pub latency_sum: Duration,
 }
 
 impl Counter {
     /// Accumulate metrics from a single iteration report.
-    pub fn append(&mut self, stats: &IterReport) {
+    pub fn record(&mut self, report: &IterReport) {
         self.iters += 1;
-        self.items += stats.items;
-        self.bytes += stats.bytes;
-        self.duration += stats.duration;
+        self.items += report.items;
+        self.bytes += report.bytes;
+        self.latency_sum += report.duration;
     }
 }
 
@@ -54,7 +54,7 @@ impl std::ops::SubAssign<&Counter> for Counter {
         self.iters -= rhs.iters;
         self.items -= rhs.items;
         self.bytes -= rhs.bytes;
-        self.duration -= rhs.duration;
+        self.latency_sum -= rhs.latency_sum;
     }
 }
 


### PR DESCRIPTION
## Description

This PR refactors the internal stats module naming to better reflect semantics and reduce ambiguity.

Key renames (no behavior change intended):
- `Counter.duration` -> `Counter.latency_sum`
- `Counter.append()` / `IterStats.append()` -> `record()`
- `IterStats.counter` / `IterStats.details` -> `IterStats.overall` / `IterStats.by_status`
- Window types -> `StatsWindow`, `MultiScaleStatsWindow`, `RecentStatsWindow`
- Multi-scale tick -> `tick` field + `tick()` method

## Related Issue

N/A

## Checklist

- [x] I have tested my changes locally (`cargo test`)
- [x] I have updated documentation if needed (rustdoc/comments updated alongside renames)
