### PR TITLE
feat(tui): add BenchPhase and RunState for progress display

### DIFF
--- a/src/collector/tui/state.rs
+++ b/src/collector/tui/state.rs
@@ -1,8 +1,10 @@
 use std::{fmt, time::Duration};
 
+use crate::phase::RunState;
+
 pub(super) struct TuiCollectorState {
     pub(super) tm_win: TimeWindowMode,
-    pub(super) finished: bool,
+    pub(super) run_state: RunState,
     #[cfg(feature = "tracing")]
     pub(super) log: super::tui_log::LogState,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@
 pub mod clock;
 mod duration;
 mod histogram;
+mod phase;
 mod report;
 mod runner;
 mod status;
@@ -68,6 +69,7 @@ pub mod collector;
 pub mod reporter;
 
 pub use crate::{
+    phase::{BenchPhase, RunState},
     report::BenchReport,
     report::IterReport,
     runner::BenchOpts,

--- a/src/phase.rs
+++ b/src/phase.rs
@@ -1,0 +1,37 @@
+/// Current phase of the benchmark execution.
+#[derive(Clone, Debug, Default)]
+pub enum BenchPhase {
+    /// Waiting to start.
+    #[default]
+    Pending,
+    /// Workers initializing state and running setup.
+    Setup {
+        /// Number of workers that have completed setup.
+        completed: usize,
+        /// Total number of workers.
+        total: usize,
+    },
+    /// Running warmup iterations (results discarded).
+    Warmup {
+        /// Number of warmup iterations completed.
+        completed: u64,
+        /// Total number of warmup iterations.
+        total: u64,
+    },
+    /// Main benchmark phase.
+    Bench,
+}
+
+/// Current run state of the benchmark.
+///
+/// State transitions: `Running ↔ Paused → Finished` (Finished is terminal)
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum RunState {
+    /// Benchmark is actively running.
+    #[default]
+    Running,
+    /// Benchmark is paused (can resume to Running).
+    Paused,
+    /// Benchmark has finished (terminal state).
+    Finished,
+}


### PR DESCRIPTION
## Description

Introduce two orthogonal state enums for better progress tracking:

- **BenchPhase**: `Pending → Setup → Warmup → Bench` (execution stages)
- **RunState**: `Running ↔ Paused → Finished` (runtime control)

The TUI progress bar now displays phase-specific information:
- **Setup**: shows worker initialization progress (e.g., "Setup: 3 / 10")
- **Warmup**: shows warmup iteration progress (e.g., "Warmup: 50 / 100")
- **Bench**: shows time/iteration progress as before

Also fixes typo: `guage` → `gauge`

## Related Issue

N/A

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if needed