### PR TITLE
feat(api): add BenchOpts builder and defaults

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -231,6 +231,7 @@ pub struct BenchCli {
 
 impl BenchCli {
     pub(crate) fn bench_opts(&self, clock: Clock) -> BenchOpts {
+        // Keep an explicit struct literal here so adding a new BenchOpts field forces an update at compile time.
         BenchOpts {
             clock,
             concurrency: self.concurrency.get(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ pub use crate::{
     report::BenchReport,
     report::IterReport,
     runner::BenchOpts,
+    runner::BenchOptsBuilder,
     runner::IterInfo,
     runner::{BenchSuite, StatelessBenchSuite},
     status::{Status, StatusKind},


### PR DESCRIPTION
## Description

Add ergonomic construction helpers for `BenchOpts`:

- Add `Default` so callers can use `..Default::default()` instead of spelling every field.
- Add `BenchOpts::builder()` / `BenchOptsBuilder` to avoid `#[cfg]` noise around feature-gated fields.
- `BenchOptsBuilder::rate()` is always available:
  - with `rate_limit` enabled: converts to `NonZeroU32` and rejects `0`
  - with `rate_limit` disabled: `build()` returns a clear error pointing to the feature
- Keep `BenchCli::bench_opts` as an explicit struct literal so adding a new `BenchOpts` field is caught at compile time.
- Update internal runner tests to use the builder where it reduces boilerplate.

Testing:
- `cargo test --all-features`
- `cargo test --no-default-features`

## Related Issue

Closes #50.

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if needed