### PR TITLE
refactor(pause)!: replace pause watch channel with PauseControl (#52)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /.worktrees
+/tags

--- a/src/collector/tui/input.rs
+++ b/src/collector/tui/input.rs
@@ -39,14 +39,14 @@ impl super::TuiCollector {
                                     clock.resume();
                                 }
                                 self.state.run_state = RunState::Running;
-                                self.run_state_tx.send_replace(self.state.run_state);
+                                self.pause.resume();
                             }
                             RunState::Running => {
                                 if is_bench_phase {
                                     clock.pause();
                                 }
                                 self.state.run_state = RunState::Paused;
-                                self.run_state_tx.send_replace(self.state.run_state);
+                                self.pause.pause();
                             }
                             RunState::Finished => {}
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub mod collector;
 pub mod reporter;
 
 pub use crate::{
-    phase::{BenchPhase, RunState},
+    phase::{BenchPhase, PauseControl, RunState},
     report::BenchReport,
     report::IterReport,
     runner::BenchOpts,

--- a/src/phase.rs
+++ b/src/phase.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
 /// Current phase of the benchmark execution.
 #[derive(Clone, Debug, Default)]
 pub enum BenchPhase {
@@ -34,4 +36,66 @@ pub enum RunState {
     Paused,
     /// Benchmark has finished (terminal state).
     Finished,
+}
+
+/// Pause/resume control shared between the runner and the TUI.
+///
+/// This is intentionally a small abstraction:
+/// - Fast path (`!paused`) is a single atomic load.
+/// - Pause wait is event-driven via `Notify`.
+///
+/// Correctness note: `wait_if_paused()` must subscribe to `Notify` *before*
+/// re-checking `paused` to avoid missing a `resume()` notification.
+#[derive(Debug, Default)]
+pub struct PauseControl {
+    paused: AtomicBool,
+    resume_notify: tokio::sync::Notify,
+}
+
+impl PauseControl {
+    /// Create a new pause controller in the running (not paused) state.
+    pub fn new() -> Self {
+        Self {
+            paused: AtomicBool::new(false),
+            resume_notify: tokio::sync::Notify::new(),
+        }
+    }
+
+    /// Returns `true` if the benchmark is currently paused.
+    #[inline]
+    pub fn is_paused(&self) -> bool {
+        self.paused.load(Ordering::Acquire)
+    }
+
+    /// Pause the benchmark.
+    #[inline]
+    pub fn pause(&self) {
+        self.paused.store(true, Ordering::Release);
+    }
+
+    /// Resume the benchmark.
+    #[inline]
+    pub fn resume(&self) {
+        self.paused.store(false, Ordering::Release);
+        // Wake all paused workers.
+        self.resume_notify.notify_waiters();
+    }
+
+    /// Wait until the benchmark is resumed, if it is currently paused.
+    #[inline]
+    pub async fn wait_if_paused(&self) {
+        // Fast path: avoid creating a `notified()` future in the steady-state.
+        if !self.is_paused() {
+            return;
+        }
+
+        loop {
+            // Subscribe first to avoid missing a concurrent `resume()`.
+            let notified = self.resume_notify.notified();
+            if !self.is_paused() {
+                return;
+            }
+            notified.await;
+        }
+    }
 }


### PR DESCRIPTION
## Description

Replace the watch-based pause mechanism with `PauseControl` (`AtomicBool` + `Notify`) shared between the runner and TUI.

- Remove runner dependency on `watch::Receiver<RunState>`; steady-state pause check is a single atomic load
- Use a subscribe-first `Notify` wait to avoid lost resume notifications when resume races with waiter registration
- Add an ignored release-mode throughput test for the pause hot path (`perf_pause_hotpath_throughput`)
- Ignore generated ctags `tags` file

### Breaking changes
- `TuiCollector::new` now takes `Arc<PauseControl>` instead of `watch::Sender<RunState>`
- `Runner::new` now takes `Arc<PauseControl>` instead of `watch::Receiver<RunState>`

### Testing
- `cargo fmt --check`
- `cargo test --all-features`
- `cargo test --release perf_pause_hotpath_throughput -- --ignored --nocapture`

## Related Issue

Closes #52

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if needed